### PR TITLE
Set up Angular app for deployment on Vercel

### DIFF
--- a/financetracker.client/angular.json
+++ b/financetracker.client/angular.json
@@ -26,6 +26,7 @@
             "outputPath": "dist/financetracker.client",
             "index": "src/index.html",
             "browser": "src/main.ts",
+            "baseHref": "/",
             "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "assets": [

--- a/financetracker.client/vercel.json
+++ b/financetracker.client/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
- Added `baseHref` in `angular.json` to configure the base URL for proper client-side routing.
- Created `vercel.json` with a `rewrites` rule to redirect all paths to `index.html`, enabling SPA routing on Vercel.